### PR TITLE
feat: form_handling

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@hookform/resolvers": "^5.0.1",
         "@mui/icons-material": "^7.0.2",
         "@mui/material": "^7.0.2",
         "@tanstack/react-query": "^5.76.1",
@@ -18,6 +19,7 @@
         "axios": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.56.4",
         "react-router": "^7.5.1",
         "react-router-dom": "^7.5.1",
         "styled-components": "^6.1.17",
@@ -1198,6 +1200,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1886,6 +1900,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -4267,6 +4287,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.56.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.4.tgz",
+      "integrity": "sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@hookform/resolvers": "^5.0.1",
     "@mui/icons-material": "^7.0.2",
     "@mui/material": "^7.0.2",
     "@tanstack/react-query": "^5.76.1",
@@ -20,6 +21,7 @@
     "axios": "^1.9.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.56.4",
     "react-router": "^7.5.1",
     "react-router-dom": "^7.5.1",
     "styled-components": "^6.1.17",

--- a/frontend/src/entity/PlayerCard/index.ts
+++ b/frontend/src/entity/PlayerCard/index.ts
@@ -1,1 +1,2 @@
 export { PlayerCard, PlayerCardsList } from "./ui";
+export { getPlayersByYear, type PlayerPositions, type Player } from "./model";

--- a/frontend/src/entity/PlayerCard/model/api.ts
+++ b/frontend/src/entity/PlayerCard/model/api.ts
@@ -5,21 +5,27 @@ import type { getPlayerResponse } from "./types";
 type GetPlayersByYearProps = {
   year: number;
   page?: number;
+  league?: string;
+  per_page?: number;
   signal: AbortSignal;
 };
 
 export const getPlayersByYear = async ({
   year,
-  page,
+  page = 1,
   signal,
+  league,
+  per_page,
 }: GetPlayersByYearProps): Promise<getPlayerResponse | undefined> => {
   try {
-    const url = `/players-by-year?year=${year}&page=${page}&per_page=${PLAYER_CARDS_PER_PAGE}`;
+    const perPageParam = per_page ? `&per_page=${per_page}` : "";
+    const leagueParam = league ? `&league=${league}` : "";
+    const url = `/players-by-year?year=${year}&page=${page}${perPageParam}${leagueParam}`;
     const response = await $api.get(url, { signal });
 
     return response.data;
   } catch (e) {
-    console.error("Error when try to fetch players by year:", e);
+    throw new Error("Error when try to fetch players by year");
   }
 };
 
@@ -29,7 +35,12 @@ export const getPlayersListInfinityQueryOptions = ({
   return infiniteQueryOptions({
     queryKey: ["players", { year }],
     queryFn: ({ signal, pageParam }) =>
-      getPlayersByYear({ year, page: pageParam, signal }),
+      getPlayersByYear({
+        year,
+        page: pageParam,
+        signal,
+        per_page: PLAYER_CARDS_PER_PAGE,
+      }),
     initialPageParam: 1,
     getNextPageParam: (lastPage) =>
       lastPage && lastPage?.page < lastPage?.totalPages

--- a/frontend/src/entity/PlayerCard/model/index.ts
+++ b/frontend/src/entity/PlayerCard/model/index.ts
@@ -1,2 +1,2 @@
-export type { Player } from "./types";
+export type { Player, PlayerPositions } from "./types";
 export { getPlayersByYear, getPlayersListInfinityQueryOptions } from "./api";

--- a/frontend/src/entity/PlayerCard/model/types/index.ts
+++ b/frontend/src/entity/PlayerCard/model/types/index.ts
@@ -1,1 +1,1 @@
-export type { Player, getPlayerResponse } from "./player";
+export type { Player, getPlayerResponse, PlayerPositions } from "./player";

--- a/frontend/src/entity/PlayerCard/model/types/player.ts
+++ b/frontend/src/entity/PlayerCard/model/types/player.ts
@@ -83,5 +83,11 @@ export const GetPlayersByYearResponseSchema = z.object({
   data: z.array(PlayerWithStatsSchema),
 });
 
+export type PlayerPositions =
+  | "Goalkeeper"
+  | "Defender"
+  | "Midfielder"
+  | "Attacker";
+
 export type Player = z.infer<typeof PlayerWithStatsSchema>;
 export type getPlayerResponse = z.infer<typeof GetPlayersByYearResponseSchema>;

--- a/frontend/src/entity/PlayerCard/ui/PlayerCardsList/PlayerCardsList.tsx
+++ b/frontend/src/entity/PlayerCard/ui/PlayerCardsList/PlayerCardsList.tsx
@@ -27,7 +27,11 @@ export const PlayerCardsList: FC = () => {
   });
 
   if (error) {
-    return <Typography>{error.message}</Typography>;
+    return (
+      <Typography color="error">
+        Error when trying to get player data
+      </Typography>
+    );
   }
 
   if (isPending) {

--- a/frontend/src/entity/TeamCard/index.ts
+++ b/frontend/src/entity/TeamCard/index.ts
@@ -4,4 +4,4 @@ export {
   TeamCardStatisticsList,
   TeamCardsList,
 } from "./ui";
-export type { Team } from "./model";
+export { type Team, type Country, CountrySchema } from "./model";

--- a/frontend/src/entity/TeamCard/model/api.ts
+++ b/frontend/src/entity/TeamCard/model/api.ts
@@ -19,7 +19,7 @@ export const getTeamsByYear = async ({
 
     return response.data;
   } catch (e) {
-    console.error("Error when try to fetch teams by year:", e);
+    throw new Error("Error when try to fetch teams by year");
   }
 };
 

--- a/frontend/src/entity/TeamCard/model/index.ts
+++ b/frontend/src/entity/TeamCard/model/index.ts
@@ -1,2 +1,7 @@
-export type { Team, getTeamResponse } from "./types";
+export {
+  type Team,
+  type getTeamResponse,
+  type Country,
+  CountrySchema,
+} from "./types";
 export { getTeamsByYear, getTeamsByYearInfinityQueryOptions } from "./api";

--- a/frontend/src/entity/TeamCard/model/types/index.ts
+++ b/frontend/src/entity/TeamCard/model/types/index.ts
@@ -1,1 +1,6 @@
-export type { Team, getTeamResponse } from "./team";
+export {
+  type Team,
+  type getTeamResponse,
+  type Country,
+  CountrySchema,
+} from "./team";

--- a/frontend/src/entity/TeamCard/model/types/team.ts
+++ b/frontend/src/entity/TeamCard/model/types/team.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const CountrySchema = z.object({
+export const CountrySchema = z.object({
   name: z.string(),
   code: z.string(),
   flag: z.string().url(),
@@ -51,3 +51,4 @@ export const TeamWithStatsResponseSchema = z.object({
 
 export type Team = z.infer<typeof TeamWithStatsSchema>;
 export type getTeamResponse = z.infer<typeof TeamWithStatsResponseSchema>;
+export type Country = z.infer<typeof CountrySchema>;

--- a/frontend/src/entity/TeamCard/ui/TeamCardStatisticsList/TeamCardStatisticsList.tsx
+++ b/frontend/src/entity/TeamCard/ui/TeamCardStatisticsList/TeamCardStatisticsList.tsx
@@ -26,7 +26,9 @@ export const TeamCardStatisticsList: FC = () => {
   });
 
   if (error) {
-    return <Typography>{error.message}</Typography>;
+    return (
+      <Typography color="error">Error when trying to get teams data</Typography>
+    );
   }
 
   if (isPending) {

--- a/frontend/src/entity/index.ts
+++ b/frontend/src/entity/index.ts
@@ -4,5 +4,13 @@ export {
   type Team,
   TeamCardStatisticsList,
   TeamCardsList,
+  type Country,
+  CountrySchema,
 } from "./TeamCard";
-export { PlayerCard, PlayerCardsList } from "./PlayerCard";
+export {
+  PlayerCard,
+  PlayerCardsList,
+  getPlayersByYear,
+  type PlayerPositions,
+  type Player,
+} from "./PlayerCard";

--- a/frontend/src/feature/CreateTeamForm/index.ts
+++ b/frontend/src/feature/CreateTeamForm/index.ts
@@ -1,0 +1,1 @@
+export { CreateTeamForm } from "./ui";

--- a/frontend/src/feature/CreateTeamForm/model/api.ts
+++ b/frontend/src/feature/CreateTeamForm/model/api.ts
@@ -1,0 +1,92 @@
+import { queryOptions } from "@tanstack/react-query";
+import { getPlayersByYear, type Country } from "../../../entity";
+import { $api } from "../../../shared";
+import type { LeagueResponse, LineupResponse } from "./types";
+
+type GetAbortSignalProps = {
+  signal: AbortSignal;
+};
+
+export const getCountries = async ({
+  signal,
+}: GetAbortSignalProps): Promise<Country[] | undefined> => {
+  try {
+    const response = await $api.get("/countries", {
+      signal,
+    });
+
+    return response.data;
+  } catch (e) {
+    console.error("Error when try to fetch countries");
+  }
+};
+
+export const getLineups = async ({
+  signal,
+}: GetAbortSignalProps): Promise<LineupResponse[] | undefined> => {
+  try {
+    const response = await $api.get("/lineups", {
+      signal,
+    });
+
+    return response.data;
+  } catch (e) {
+    console.error("Error when try to fetch lineups");
+  }
+};
+
+export const getLeagues = async ({
+  signal,
+}: GetAbortSignalProps): Promise<LeagueResponse[] | undefined> => {
+  try {
+    const response = await $api.get("/leagues", {
+      signal,
+    });
+
+    return response.data;
+  } catch (e) {
+    console.error("Error when try to fetch leagues");
+  }
+};
+
+type GetPlayersQueryOptionsProps = {
+  competition: string;
+  country: string;
+};
+
+export const getPlayersQueryOptions = ({
+  competition,
+  country,
+}: GetPlayersQueryOptionsProps) => {
+  return queryOptions({
+    queryKey: ["players", competition, country],
+    queryFn: ({ signal }) =>
+      getPlayersByYear({
+        signal,
+        year: 2023,
+        league: competition,
+        per_page: 100,
+      }),
+    enabled: Boolean(competition),
+  });
+};
+
+type PostFantasyTeamProps = {
+  data: {
+    name: string;
+    country: string;
+    competition: string;
+    lineup: string;
+    players: string[];
+  };
+};
+
+export const postFantasyTeams = async ({ data }: PostFantasyTeamProps) => {
+  try {
+    const response = await $api.post("/fantasy-teams", data);
+
+    return response.data;
+  } catch (e) {
+    throw new Error("Error when try to send new team data");
+  }
+};

--- a/frontend/src/feature/CreateTeamForm/model/index.ts
+++ b/frontend/src/feature/CreateTeamForm/model/index.ts
@@ -1,0 +1,14 @@
+export {
+  type FormFields,
+  FormFieldsSchema,
+  type LineupResponse,
+  type FormationPlayers,
+  type PlayerOptions,
+} from "./types";
+export {
+  getCountries,
+  getLineups,
+  getLeagues,
+  postFantasyTeams,
+  getPlayersQueryOptions,
+} from "./api";

--- a/frontend/src/feature/CreateTeamForm/model/types/form.ts
+++ b/frontend/src/feature/CreateTeamForm/model/types/form.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { CountrySchema } from "../../../../entity";
+
+const NameSchema = z
+  .string()
+  .nonempty("Please specify a team name")
+  .min(3, "Must contain at least 3 letters")
+  .max(30, "30 letters is the maximum length");
+
+const PlayersSchema = z
+  .array(
+    z.object({
+      name: z.string(),
+      position: z.string(),
+      id: z.string(),
+    }),
+  )
+  .refine((arr) => arr.length === 11, { message: "Choose 11 players" });
+
+export const FormFieldsSchema = z.object({
+  name: NameSchema,
+  country: z.string().nonempty("Please specify a country"),
+  competition: z.string().nonempty("Please specify a competition"),
+  lineup: z.string().nonempty("Please specify a line-up"),
+  players: PlayersSchema,
+});
+
+const FormationSchema = z.object({
+  gk: z.number(),
+  def: z.number(),
+  mid: z.number(),
+  fwd: z.number(),
+});
+
+const LineupSchema = z.object({
+  name: z.string(),
+  formation: FormationSchema,
+});
+
+const LeagueSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  type: z.string(),
+  logo: z.string().url(),
+  country: CountrySchema,
+});
+
+export type LineupResponse = z.infer<typeof LineupSchema>;
+export type FormFields = z.infer<typeof FormFieldsSchema>;
+export type LeagueResponse = z.infer<typeof LeagueSchema>;
+export type FormationPlayers = z.infer<typeof FormationSchema>;
+export type PlayerOptions = z.infer<typeof PlayersSchema>;

--- a/frontend/src/feature/CreateTeamForm/model/types/index.ts
+++ b/frontend/src/feature/CreateTeamForm/model/types/index.ts
@@ -1,0 +1,8 @@
+export {
+  type FormFields,
+  FormFieldsSchema,
+  type LineupResponse,
+  type LeagueResponse,
+  type FormationPlayers,
+  type PlayerOptions,
+} from "./form";

--- a/frontend/src/feature/CreateTeamForm/ui/CreateTeamForm/CreateTeamForm.style.ts
+++ b/frontend/src/feature/CreateTeamForm/ui/CreateTeamForm/CreateTeamForm.style.ts
@@ -1,0 +1,70 @@
+import {
+  Box,
+  Button,
+  FormControl,
+  FormHelperText,
+  styled,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { grey } from "@mui/material/colors";
+
+export const CustomForm = styled("form")(() => ({
+  display: "flex",
+  flexDirection: "column",
+  width: "320px",
+}));
+
+export const CustomFormControl = styled(FormControl)(() => ({
+  height: "100%",
+  marginTop: "24px",
+  "& .MuiAutocomplete-groupLabel": {
+    backgroundColor: grey[200],
+  },
+
+  "& .css-o5oj2-MuiAutocomplete-root .MuiAutocomplete-inputRoot": {
+    display: "flex",
+    flexWrap: "nowrap",
+  },
+}));
+
+export const CustomTextField = styled(TextField)(() => ({
+  "& .MuiInputBase-input": {
+    height: "12px",
+    fontSize: "16px",
+    lineHeight: "19px",
+    fontWeight: 400,
+  },
+  "& label": {
+    fontSize: "16px",
+    lineHeight: "19px",
+    fontWeight: 400,
+    height: "20px",
+    top: "-4px",
+  },
+}));
+
+export const CustomButton = styled(Button)(() => ({
+  backgroundColor: grey[300],
+  color: "black",
+  width: "69px",
+  height: "36px",
+  marginTop: "24px",
+}));
+
+export const ButtonsWrapper = styled(Box)(() => ({
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: "8px",
+}));
+
+export const CustomFormHelperText = styled(FormHelperText)(({ theme }) => ({
+  color: theme.palette.error.main,
+}));
+
+export const CustomTypography = styled(Typography)(() => ({
+  width: "100%",
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+}));

--- a/frontend/src/feature/CreateTeamForm/ui/CreateTeamForm/CreateTeamForm.tsx
+++ b/frontend/src/feature/CreateTeamForm/ui/CreateTeamForm/CreateTeamForm.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState, type FC } from "react";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  type FormFields,
+  FormFieldsSchema,
+  getCountries,
+  getLeagues,
+  getLineups,
+  getPlayersQueryOptions,
+  postFantasyTeams,
+} from "../../model";
+import {
+  ButtonsWrapper,
+  CustomButton,
+  CustomForm,
+} from "./CreateTeamForm.style";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  AutocompleteController,
+  PlayersController,
+  TextFieldController,
+} from "../FormControllers";
+import {
+  CustomHeaderTypography,
+  FetchDataModal,
+  RoutePaths,
+} from "../../../../shared";
+import { Link, useNavigate } from "react-router";
+
+const countryMock = "GB-ENG";
+const competitionMock = {
+  id: "39",
+  name: "Premier League",
+}; // will get mock data from TeamCardsList with MobX in next PR
+
+type CreateTeamFormProps = {
+  editTeam?: boolean;
+};
+
+export const CreateTeamForm: FC<CreateTeamFormProps> = ({ editTeam }) => {
+  const navigate = useNavigate();
+  const {
+    control,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { isValid },
+  } = useForm<FormFields>({
+    defaultValues: {
+      name: "",
+      country: editTeam ? countryMock : "",
+      competition: editTeam ? competitionMock.name : "",
+      lineup: "",
+      players: [],
+    },
+    mode: "onBlur",
+    reValidateMode: "onBlur",
+    resolver: zodResolver(FormFieldsSchema),
+  });
+  const defaultFormation = {
+    Goalkeeper: 0,
+    Defender: 0,
+    Midfielder: 0,
+    Attacker: 0,
+  };
+  const [playersFormation, setPlayersFormation] = useState(defaultFormation);
+  const selectedPlayers = watch("players");
+  const countryInputValue = watch("country");
+  const competitionInputValue = watch("competition");
+  const lineupInputValue = watch("lineup");
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    navigate(-1);
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: biome incorrectly defines the list of required dependencies
+  useEffect(() => {
+    if (!editTeam) setValue("competition", "");
+  }, [countryInputValue]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: biome incorrectly defines the list of required dependencies
+  useEffect(() => {
+    setValue("players", []);
+  }, [countryInputValue, competitionInputValue, lineupInputValue]);
+
+  const { data: countriesResponse, error: countryError } = useQuery({
+    queryKey: ["countries"],
+    queryFn: ({ signal }) => getCountries({ signal }),
+  });
+
+  const { data: lineupsResponse, error: lineupsError } = useQuery({
+    queryKey: ["lineups"],
+    queryFn: ({ signal }) => getLineups({ signal }),
+  });
+
+  const { data: competitionsResponse, error: competitionsError } = useQuery({
+    queryKey: ["leagues"],
+    queryFn: ({ signal }) => getLeagues({ signal }),
+  });
+
+  const availableCompetitionData =
+    competitionsResponse?.filter(
+      (competition) => competition.country.name === countryInputValue,
+    ) || [];
+
+  const availableCompetitionName = availableCompetitionData.map(
+    (competition) => competition.name,
+  );
+
+  const availableCompetitionId = editTeam
+    ? competitionMock.id
+    : availableCompetitionData
+        ?.map((competition) => competitionInputValue && competition.id)[0]
+        ?.toString();
+
+  const { data: playersResponse, error: playersError } = useQuery({
+    ...getPlayersQueryOptions({
+      competition: availableCompetitionId,
+      country: countryInputValue,
+    }),
+  });
+
+  const {
+    mutate: createTeamMutation,
+    isError: isCreateTeamError,
+    isPending: isTeamCreating,
+    isSuccess: isCreateTeamSuccess,
+  } = useMutation({
+    mutationFn: postFantasyTeams,
+  });
+
+  const countryNames = countriesResponse?.map((country) => country.name) || [];
+  const lineupNames = lineupsResponse?.map((lineup) => lineup.name) || [];
+
+  const editModeCountryInputCode = editTeam ? countryMock : "";
+  const createModeCountryInputCode =
+    countryInputValue && countriesResponse && !editTeam
+      ? countriesResponse?.filter(
+          (country) => countryInputValue === country.name,
+        )[0].code
+      : "";
+
+  const countryInputCode = editTeam
+    ? editModeCountryInputCode
+    : createModeCountryInputCode;
+
+  useEffect(() => {
+    lineupsResponse?.map((lineup) => {
+      if (lineup.name === lineupInputValue) {
+        setPlayersFormation({
+          Goalkeeper: lineup.formation.gk,
+          Defender: lineup.formation.def,
+          Midfielder: lineup.formation.mid,
+          Attacker: lineup.formation.fwd,
+        });
+      }
+    });
+  }, [lineupInputValue, lineupsResponse]);
+
+  const onSubmit: SubmitHandler<FormFields> = (data) => {
+    const formattedData = {
+      ...data,
+      country: countryInputCode,
+      competition: availableCompetitionId,
+      players: data.players.map((player) => player.id),
+    };
+    createTeamMutation({ data: formattedData });
+    handleOpenModal();
+  };
+
+  const editModePlayerOptionsData =
+    editTeam && playersResponse?.data ? playersResponse?.data : [];
+  const createModePlayerOptionsData =
+    lineupInputValue && playersResponse?.data ? playersResponse.data : [];
+  const playerOptionsData = editTeam
+    ? editModePlayerOptionsData
+    : createModePlayerOptionsData;
+
+  if (countryError || lineupsError || competitionsError || playersError) {
+    return (
+      <CustomHeaderTypography
+        color="error"
+        title="Error when trying to fetch data"
+      />
+    );
+  }
+
+  return (
+    <>
+      <FetchDataModal
+        isModalOpen={isModalOpen}
+        isError={isCreateTeamError}
+        isPending={isTeamCreating}
+        isSuccess={isCreateTeamSuccess}
+        handleCloseModal={handleCloseModal}
+        successMessage="The new team has been successfully created!"
+      />
+      <CustomForm noValidate onSubmit={handleSubmit(onSubmit)}>
+        <TextFieldController control={control} name="name" label="Team name" />
+        {editTeam ? (
+          <>
+            <AutocompleteController
+              options={countryNames}
+              control={control}
+              name={"country"}
+              label={"Country"}
+              disabled
+            />
+            <AutocompleteController
+              options={availableCompetitionName}
+              control={control}
+              name={"competition"}
+              label={"Competition"}
+              disabled
+            />
+          </>
+        ) : (
+          <>
+            <AutocompleteController
+              options={countryNames}
+              control={control}
+              name={"country"}
+              label={"Country"}
+            />
+            <AutocompleteController
+              options={availableCompetitionName}
+              control={control}
+              name={"competition"}
+              label={"Competition"}
+            />
+          </>
+        )}
+        <AutocompleteController
+          options={lineupNames}
+          control={control}
+          name={"lineup"}
+          label={"Team line-up"}
+        />
+        <PlayersController
+          control={control}
+          playersFormation={playersFormation}
+          playerOptionsData={playerOptionsData}
+          selectedPlayers={selectedPlayers}
+        />
+        <ButtonsWrapper>
+          <Link to={RoutePaths.fantasy_teams}>
+            <CustomButton type="button">BACK</CustomButton>
+          </Link>
+          <CustomButton type="submit" disabled={!isValid}>
+            SAVE
+          </CustomButton>
+        </ButtonsWrapper>
+      </CustomForm>
+    </>
+  );
+};

--- a/frontend/src/feature/CreateTeamForm/ui/CreateTeamForm/index.ts
+++ b/frontend/src/feature/CreateTeamForm/ui/CreateTeamForm/index.ts
@@ -1,0 +1,1 @@
+export { CreateTeamForm } from "./CreateTeamForm";

--- a/frontend/src/feature/CreateTeamForm/ui/FormControllers/AutocompleteController.tsx
+++ b/frontend/src/feature/CreateTeamForm/ui/FormControllers/AutocompleteController.tsx
@@ -1,0 +1,58 @@
+import { Autocomplete } from "@mui/material";
+import { type Control, Controller } from "react-hook-form";
+import {
+  CustomFormControl,
+  CustomTextField,
+  CustomFormHelperText,
+} from "../CreateTeamForm/CreateTeamForm.style";
+import type { FC } from "react";
+import type { FormFields } from "../../model";
+
+type AutocompleteControllerProps = {
+  control: Control<FormFields>;
+  options: string[];
+  name: keyof FormFields;
+  label: string;
+  disabled?: boolean;
+  defaultValue?: string;
+};
+
+export const AutocompleteController: FC<AutocompleteControllerProps> = ({
+  control,
+  options,
+  name,
+  label,
+  disabled,
+}) => (
+  <Controller
+    name={name}
+    control={control}
+    render={({
+      field: { value, onChange, onBlur, ref },
+      fieldState: { error },
+    }) => (
+      <CustomFormControl>
+        <Autocomplete
+          disablePortal
+          options={options}
+          value={typeof value === "string" ? value : undefined}
+          onChange={(_, value) => onChange(value)}
+          disableClearable
+          disabled={disabled}
+          renderInput={(params: object) => (
+            <CustomTextField
+              {...params}
+              name={name}
+              label={label}
+              required
+              inputRef={ref}
+              onBlur={onBlur}
+              error={Boolean(error)}
+            />
+          )}
+        />
+        <CustomFormHelperText>{error?.message ?? ""}</CustomFormHelperText>
+      </CustomFormControl>
+    )}
+  />
+);

--- a/frontend/src/feature/CreateTeamForm/ui/FormControllers/PlayersController.tsx
+++ b/frontend/src/feature/CreateTeamForm/ui/FormControllers/PlayersController.tsx
@@ -1,0 +1,121 @@
+import { Autocomplete, Checkbox } from "@mui/material";
+import type { FC } from "react";
+import { type Control, Controller } from "react-hook-form";
+import type { Player, PlayerPositions } from "../../../../entity";
+import {
+  CustomFormControl,
+  CustomTypography,
+  CustomTextField,
+  CustomFormHelperText,
+} from "../CreateTeamForm/CreateTeamForm.style";
+import CheckBoxIcon from "@mui/icons-material/CheckBox";
+import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
+import type { FormFields, PlayerOptions } from "../../model";
+import { playerPositionsOrder } from "../../../../shared";
+
+const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
+const checkedIcon = <CheckBoxIcon fontSize="small" />;
+
+type PlayersControllerProps = {
+  control: Control<FormFields>;
+  playerOptionsData: Player[] | [];
+  selectedPlayers: PlayerOptions | [];
+  playersFormation: { [n in PlayerPositions]: number };
+};
+
+export const PlayersController: FC<PlayersControllerProps> = ({
+  control,
+  playerOptionsData,
+  selectedPlayers,
+  playersFormation,
+}) => {
+  const playerOptions = playerOptionsData
+    ?.map((player) => {
+      if (player.games.position) {
+        return {
+          position: player.games.position,
+          name: player.player.name,
+          id: player.player.id,
+        };
+      }
+    })
+    .sort((a, b) =>
+      playerPositionsOrder[a?.position as PlayerPositions] >
+      playerPositionsOrder[b?.position as PlayerPositions]
+        ? 1
+        : -1,
+    );
+  return (
+    <Controller
+      name="players"
+      control={control}
+      defaultValue={[]}
+      render={({
+        field: { value, onChange, onBlur, ref },
+        fieldState: { error },
+      }) => (
+        <CustomFormControl>
+          <Autocomplete
+            multiple
+            value={value}
+            options={playerOptions}
+            groupBy={(option) => option?.position || ""}
+            getOptionLabel={(option) => option?.name || ""}
+            disablePortal
+            onChange={(_, newValue) => onChange(newValue)}
+            disableCloseOnSelect
+            isOptionEqualToValue={(option, value) =>
+              option?.name === value?.name
+            }
+            getOptionDisabled={(option) => {
+              if (option?.position) {
+                const countForPosition = selectedPlayers.filter(
+                  (player) => player.position === option.position,
+                ).length;
+
+                return (
+                  countForPosition >=
+                    playersFormation[option.position as PlayerPositions] &&
+                  !selectedPlayers.some((player) => player.id === option.id)
+                );
+              }
+              return false;
+            }}
+            renderTags={() => {
+              return (
+                <CustomTypography>
+                  {value.map((option) => option.name).join(", ")}
+                </CustomTypography>
+              );
+            }}
+            renderOption={(props, option, { selected }) => {
+              const { key, ...optionProps } = props;
+              return (
+                <li key={option?.id} {...optionProps}>
+                  <Checkbox
+                    icon={icon}
+                    checkedIcon={checkedIcon}
+                    checked={selected}
+                  />
+                  {option?.name}
+                </li>
+              );
+            }}
+            renderInput={(params) => (
+              <CustomTextField
+                {...params}
+                name="players"
+                label="Players"
+                required
+                inputRef={ref}
+                onBlur={onBlur}
+                error={Boolean(error)}
+              />
+            )}
+          />
+          <CustomFormHelperText>{error?.message ?? ""}</CustomFormHelperText>
+        </CustomFormControl>
+      )}
+    />
+  );
+};

--- a/frontend/src/feature/CreateTeamForm/ui/FormControllers/TextFieldController.tsx
+++ b/frontend/src/feature/CreateTeamForm/ui/FormControllers/TextFieldController.tsx
@@ -1,0 +1,43 @@
+import type { FC } from "react";
+import { type Control, Controller } from "react-hook-form";
+import {
+  CustomFormControl,
+  CustomTextField,
+  CustomFormHelperText,
+} from "../CreateTeamForm/CreateTeamForm.style";
+import type { FormFields } from "../../model";
+
+type TextFieldControllerProps = {
+  control: Control<FormFields>;
+  name: keyof FormFields;
+  label: string;
+};
+
+export const TextFieldController: FC<TextFieldControllerProps> = ({
+  control,
+  name,
+  label,
+}) => (
+  <Controller
+    name={name}
+    control={control}
+    render={({
+      field: { value, onChange, onBlur, ref },
+      fieldState: { error },
+    }) => (
+      <CustomFormControl>
+        <CustomTextField
+          name={name}
+          label={label}
+          required
+          inputRef={ref}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          error={Boolean(error)}
+        />
+        <CustomFormHelperText>{error?.message ?? ""}</CustomFormHelperText>
+      </CustomFormControl>
+    )}
+  />
+);

--- a/frontend/src/feature/CreateTeamForm/ui/FormControllers/index.ts
+++ b/frontend/src/feature/CreateTeamForm/ui/FormControllers/index.ts
@@ -1,0 +1,3 @@
+export { AutocompleteController } from "./AutocompleteController";
+export { TextFieldController } from "./TextFieldController";
+export { PlayersController } from "./PlayersController";

--- a/frontend/src/feature/CreateTeamForm/ui/index.ts
+++ b/frontend/src/feature/CreateTeamForm/ui/index.ts
@@ -1,0 +1,1 @@
+export { CreateTeamForm } from "./CreateTeamForm";

--- a/frontend/src/feature/index.ts
+++ b/frontend/src/feature/index.ts
@@ -1,0 +1,1 @@
+export { CreateTeamForm } from "./CreateTeamForm";

--- a/frontend/src/pages/createTeamPage/CreateTeamPage.tsx
+++ b/frontend/src/pages/createTeamPage/CreateTeamPage.tsx
@@ -1,6 +1,12 @@
 import type { FC } from "react";
 import { CustomHeaderTypography } from "../../shared";
+import { CreateTeamForm } from "../../feature";
 
-const CreateTeamPage: FC = () => <CustomHeaderTypography title="Create team" />;
+const CreateTeamPage: FC = () => (
+  <>
+    <CustomHeaderTypography title="Create team" />
+    <CreateTeamForm />
+  </>
+);
 
 export default CreateTeamPage;

--- a/frontend/src/pages/editTeamPage/EditTeamPage.tsx
+++ b/frontend/src/pages/editTeamPage/EditTeamPage.tsx
@@ -1,6 +1,12 @@
 import type { FC } from "react";
 import { CustomHeaderTypography } from "../../shared";
+import { CreateTeamForm } from "../../feature";
 
-const EditTeamPage: FC = () => <CustomHeaderTypography title="Edit team" />;
+const EditTeamPage: FC = () => (
+  <>
+    <CustomHeaderTypography title="Edit team" />
+    <CreateTeamForm editTeam />
+  </>
+);
 
 export default EditTeamPage;

--- a/frontend/src/shared/consts/index.ts
+++ b/frontend/src/shared/consts/index.ts
@@ -13,3 +13,4 @@ export {
   TEAM_STATISTICS_CARDS_PER_PAGE,
   PLAYER_CARDS_PER_PAGE,
 } from "./perPageParam";
+export { playerPositionsOrder } from "./playerPositionsOrder";

--- a/frontend/src/shared/consts/playerPositionsOrder.ts
+++ b/frontend/src/shared/consts/playerPositionsOrder.ts
@@ -1,0 +1,10 @@
+import type { PlayerPositions } from "../../entity";
+
+type PlayerPositionsOrder = { [n in PlayerPositions]: number };
+
+export const playerPositionsOrder: PlayerPositionsOrder = {
+  Goalkeeper: 0,
+  Defender: 1,
+  Midfielder: 2,
+  Attacker: 3,
+};

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -4,6 +4,7 @@ export {
   TabPanel,
   CustomHeaderTypography,
   SkeletonCardsList,
+  FetchDataModal,
 } from "./ui";
 export {
   RoutePaths,
@@ -27,6 +28,7 @@ export {
   STALE_TIME,
   TEAM_STATISTICS_CARDS_PER_PAGE,
   PLAYER_CARDS_PER_PAGE,
+  playerPositionsOrder,
 } from "./consts";
 export { getDisplayString } from "./utils";
 export { queryClient, $api } from "./api";

--- a/frontend/src/shared/ui/CustomHeaderTypography/CustomHeaderTypography.style.ts
+++ b/frontend/src/shared/ui/CustomHeaderTypography/CustomHeaderTypography.style.ts
@@ -1,6 +1,6 @@
-import { styled, Typography } from "@mui/material";
+import { styled, Typography, type TypographyProps } from "@mui/material";
 
-export const CustomTypography = styled(Typography)(() => ({
+export const CustomTypography = styled(Typography)<TypographyProps>(() => ({
   "&&": {
     fontSize: "20px",
     lineHeight: "32px",

--- a/frontend/src/shared/ui/CustomHeaderTypography/CustomHeaderTypography.tsx
+++ b/frontend/src/shared/ui/CustomHeaderTypography/CustomHeaderTypography.tsx
@@ -3,8 +3,10 @@ import { CustomTypography } from "./CustomHeaderTypography.style";
 
 type CustomHeaderTypographyProps = {
   title: string;
+  color?: string;
 };
 
 export const CustomHeaderTypography: FC<CustomHeaderTypographyProps> = ({
   title,
-}) => <CustomTypography>{title}</CustomTypography>;
+  ...otherProps
+}) => <CustomTypography {...otherProps}>{title}</CustomTypography>;

--- a/frontend/src/shared/ui/FetchDataModal/FetchDataModal.style.ts
+++ b/frontend/src/shared/ui/FetchDataModal/FetchDataModal.style.ts
@@ -1,0 +1,19 @@
+import { Box, styled } from "@mui/material";
+
+export const ModalBody = styled(Box)(() => ({
+  "&&": {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: 400,
+    backgroundColor: "#ffff",
+    boxShadow: 24,
+    padding: "15px",
+  },
+}));
+
+export const ModalTextWrapper = styled(Box)(() => ({
+  display: "flex",
+  justifyContent: "center",
+}));

--- a/frontend/src/shared/ui/FetchDataModal/FetchDataModal.tsx
+++ b/frontend/src/shared/ui/FetchDataModal/FetchDataModal.tsx
@@ -1,0 +1,61 @@
+import type { FC } from "react";
+import { ModalBody, ModalTextWrapper } from "./FetchDataModal.style";
+import { Modal, Typography } from "@mui/material";
+import CircularProgress from "@mui/material/CircularProgress";
+
+type FetchDataModalProps = {
+  isModalOpen: boolean;
+  handleCloseModal: () => void;
+  isSuccess: boolean;
+  isError: boolean;
+  isPending: boolean;
+  successMessage: string;
+};
+
+export const FetchDataModal: FC<FetchDataModalProps> = ({
+  isModalOpen,
+  handleCloseModal,
+  isSuccess,
+  isError,
+  isPending,
+  successMessage,
+}) => (
+  <Modal
+    open={isModalOpen}
+    onClose={handleCloseModal}
+    aria-labelledby="modal-modal-title"
+    aria-describedby="modal-modal-description"
+  >
+    <ModalBody>
+      {isSuccess && (
+        <ModalTextWrapper>
+          <Typography
+            id="modal-modal-title"
+            variant="h6"
+            component="h2"
+            color="success"
+          >
+            {successMessage}
+          </Typography>
+        </ModalTextWrapper>
+      )}
+      {isError && (
+        <ModalTextWrapper>
+          <Typography
+            id="modal-modal-title"
+            variant="h6"
+            component="h2"
+            color="error"
+          >
+            Error sending data, please try again later
+          </Typography>
+        </ModalTextWrapper>
+      )}
+      {isPending && (
+        <ModalTextWrapper>
+          <CircularProgress />
+        </ModalTextWrapper>
+      )}
+    </ModalBody>
+  </Modal>
+);

--- a/frontend/src/shared/ui/FetchDataModal/index.ts
+++ b/frontend/src/shared/ui/FetchDataModal/index.ts
@@ -1,0 +1,1 @@
+export { FetchDataModal } from "./FetchDataModal";

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -3,3 +3,4 @@ export { CustomDropdownMenu } from "./CustomDropdownMenu";
 export { TabPanel } from "./TabPanel";
 export { CustomHeaderTypography } from "./CustomHeaderTypography";
 export { SkeletonCardsList } from "./SkeletonCardsList";
+export { FetchDataModal } from "./FetchDataModal";


### PR DESCRIPTION
added React Hook Form npm dependecy
refactored getPlayersByYear request: per_page and league parameters can be passed using a prop, added new types describing the data coming into the form, fixed error handling in getPlayers and getTeams requests by throwing new Error instead console.error added get functions for countries, leagues and lineups data, added a new team post function,
added schemas for the create team form,
added CreateTeamForm feature,
implemented player positions order in consts for the form players dropdown options, added color prop in CustomHeaderTypography component, added FetchDataModal shared component